### PR TITLE
Fix some bugs in automate-ml-for-kaggle

### DIFF
--- a/automate-ml-for-kaggle/README.md
+++ b/automate-ml-for-kaggle/README.md
@@ -55,7 +55,7 @@ First, Clone and navigate to the folder:
 
 ```bash
 git clone https://github.com/ag2ai/build-with-ag2.git
-cd build-with-ag2/game_design_agent_team
+cd build-with-ag2/automate-ml-for-kaggle
 ```
 
 Then install the required dependencies:

--- a/automate-ml-for-kaggle/requirements.txt
+++ b/automate-ml-for-kaggle/requirements.txt
@@ -1,4 +1,4 @@
-ag2[jupyter_executor]
+ag2[jupyter-executor]
 scikit-learn
 pandas
 matplotlib


### PR DESCRIPTION
Fix some errors
```
pip install "ag2[jupyter_executor]"
WARNING: ag2 0.9.1.post0 does not provide the extra 'jupyter_executor'
```
