### PR TITLE
Fixed get_order_history function -> orders is a hashmap not a list

### DIFF
--- a/e-commerce-customer-service/functions.py
+++ b/e-commerce-customer-service/functions.py
@@ -20,8 +20,8 @@ def get_order_history(context_variables: ContextVariables) -> str:
     orders = context_variables["user_info"]["orders"]
     if not orders:
         return "No order history found"
-    for order in orders:
-        order_str += f"Order Number: {order['order_number']}, Product: {order['product']}, Status: {order['status']}, link: {order['link']}\n"
+    for order_number, order in orders.items():
+        order_str += f"Order Number: {order_number}, Product: {order['product']}, Status: {order['status']}, link: {order['link']}\n"
     return order_str
 
 


### PR DESCRIPTION
Sub repository: e-commerce-customer-service

Issue faced: get_order_history function call was failing as orders from context_variables is a hashmap and not a list.

For reproduction:
Use OAI_CONFIG_LIST with model: gpt-4o-mini or gpt-4o

and run the code as is.
Ask for questions around "order history"

Please don't hesitate to ask me for additional details.