### PR TITLE
Add swarm.at settlement protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A curated collection of awesome agentic applications built with [AG2](https://gi
 - 🔏 [AutoDefense](https://github.com/XHMY/AutoDefense): Multi-agent LLM Defense against jailbreak attacks
 - 🔍 [Prompt Leakage Probing](https://github.com/airtai/prompt-leakage-probing): Framework for testing LLM agents for system prompt leaks
 - 💌 [AI-Powered Event Invitation Workflow](https://github.com/neosantara-xyz/examples/tree/main/ag2/event_invitation): Multi-agent event invitation system using Neosantara AI's Grok 4 for personalized multilingual content generation
-- 🔗 [swarm.at Settlement Protocol](https://github.com/Mediaeater/swarm.at): Settle every AG2 agent reply to an immutable hash-chained ledger via reply callback. Trust-tiered agent identities with Bayesian promotion. `pip install swarm-at-sdk[autogen]`
+- 🔗 [swarm.at Settlement Protocol](https://github.com/Mediaeater/swarm-at-ledger): Settle every AG2 agent reply to an immutable hash-chained ledger via reply callback. Trust-tiered agent identities with Bayesian promotion. `pip install swarm-at-sdk[autogen]`
 
 ## 🤝 Contributing to AG2 Open Source
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated collection of awesome agentic applications built with [AG2](https://gi
 - 🔏 [AutoDefense](https://github.com/XHMY/AutoDefense): Multi-agent LLM Defense against jailbreak attacks
 - 🔍 [Prompt Leakage Probing](https://github.com/airtai/prompt-leakage-probing): Framework for testing LLM agents for system prompt leaks
 - 💌 [AI-Powered Event Invitation Workflow](https://github.com/neosantara-xyz/examples/tree/main/ag2/event_invitation): Multi-agent event invitation system using Neosantara AI's Grok 4 for personalized multilingual content generation
+- 🔗 [swarm.at Settlement Protocol](https://github.com/Mediaeater/swarm.at): Settle every AG2 agent reply to an immutable hash-chained ledger via reply callback. Trust-tiered agent identities with Bayesian promotion. `pip install swarm-at-sdk[autogen]`
 
 ## 🤝 Contributing to AG2 Open Source
 


### PR DESCRIPTION
Adds swarm.at to the project links list.

**swarm.at** settles every AG2 agent reply to an immutable hash-chained ledger via reply callback. Agents earn trust through verified performance (untrusted -> provisional -> trusted -> senior).

```bash
pip install swarm-at-sdk[autogen]
```

```python
from swarm_at.adapters.autogen import SwarmReplyCallback
callback = SwarmReplyCallback()
agent.register_reply([autogen.Agent], callback.on_reply)
```

- **GitHub:** https://github.com/Mediaeater/swarm.at
- **PyPI:** https://pypi.org/project/swarm-at-sdk/
- **Docs:** https://swarm.at/SPEC.html